### PR TITLE
fix dropbear configure to enable building under an x32 toolchain.

### DIFF
--- a/module/dropbear
+++ b/module/dropbear
@@ -24,11 +24,18 @@ cd ..
 echo === $HOST Native build static dropbear
 
 setupfor dropbear
+if [ "$CROSS_BASE" == x32- ]
+then
+  TGT=x86_64-linux-muslx32
+else
+  TGT="$CROSS_BASE"
+fi
+
 # Repeat after me: "autoconf is useless"
 echo 'echo "$@"' > config.sub &&
 ZLIB="$(echo ../zlib*)" &&
 CFLAGS="-I $ZLIB -Os" LDFLAGS="--static -L $ZLIB" ./configure \
-  --host=${CROSS_BASE%-} &&
+  --host=${TGT%-} &&
 sed -i 's@/usr/bin/dbclient@ssh@' options.h &&
 make -j $(nproc) PROGRAMS="dropbear dbclient dropbearkey dropbearconvert scp" MULTI=1 SCPPROGRESS=1 &&
 ${CROSS_COMPILE}strip dropbearmulti &&


### PR DESCRIPTION
The build still fail regarding extended register during compilation of sha512.