### PR TITLE
Added preservation of *_proxy=|*_PROXY= variables to mkroot.sh during…

### DIFF
--- a/mkroot.sh
+++ b/mkroot.sh
@@ -17,8 +17,10 @@ then
 fi
 
 # Clear environment variables by restarting script w/bare minimum passed through
+# => preserve proxy variables for those behind a proxy server.
 [ -z "$NOCLEAR" ] &&
   exec env -i NOCLEAR=1 HOME="$HOME" PATH="$PATH" \
+    $(printenv | grep -i _proxy=) \
     CROSS_COMPILE="$CROSS_COMPILE" CROSS_SHORT="$CROSS_SHORT" "$0" "$@"
 
 # Loop collecting initial -x arguments. (Simple, can't collate ala -nl .)

--- a/mkroot.sh
+++ b/mkroot.sh
@@ -20,7 +20,7 @@ fi
 # => preserve proxy variables for those behind a proxy server.
 [ -z "$NOCLEAR" ] &&
   exec env -i NOCLEAR=1 HOME="$HOME" PATH="$PATH" \
-    $(printenv | grep -i _proxy=) \
+    $(env | grep -i _proxy=) \
     CROSS_COMPILE="$CROSS_COMPILE" CROSS_SHORT="$CROSS_SHORT" "$0" "$@"
 
 # Loop collecting initial -x arguments. (Simple, can't collate ala -nl .)


### PR DESCRIPTION
… 'Clear environment variables' step.

Without this change, the user's existing proxy configuration gets lost and they are forced to
download needed files manually.
The only way this might not work would be if 'printenv' were not supported in the current shell,
or if the output of a particular shell's 'printenv' did not conform to a 'VAR=VAL' format.

Signed-off-by: Stefan H. Driesner <driesner_stefan_h@cat.com>