### PR TITLE
Use the host's arch name in the output directory

### DIFF
--- a/mkroot.sh
+++ b/mkroot.sh
@@ -63,14 +63,15 @@ fi
 
 # Work out absolute paths to working dirctories (can override on cmdline)
 TOP="$PWD"
+HOST=$(uname -m)
 [ -z "$BUILD" ] && BUILD="$TOP/build"
 [ -z "$DOWNLOAD" ] && DOWNLOAD="$TOP/download"
 [ -z "$AIRLOCK" ] && AIRLOCK="$TOP/airlock"
-[ -z "$OUTPUT" ] && OUTPUT="$TOP/output/${CROSS_SHORT:-host}"
+[ -z "$OUTPUT" ] && OUTPUT="$TOP/output/${CROSS_SHORT:-${HOST}}"
 [ -z "$ROOT" ] && ROOT="$OUTPUT/${CROSS_BASE}root"
 
 [ -z "$N" ] && rm -rf "$ROOT"
-MYBUILD="$BUILD/${CROSS_BASE:-host-}tmp"
+MYBUILD="$BUILD/${CROSS_BASE:-${HOST}-}tmp"
 mkdir -p "$MYBUILD" "$DOWNLOAD" || exit 1
 
 ### Functions to download, extract, and clean up after source packages.

--- a/module/kernel
+++ b/module/kernel
@@ -1,7 +1,7 @@
 #!/bin/echo Use as an argument to mkroot.sh
 
-download 90ce9015379f951b4da272f25302dfa0b0bc0123 \
-  https://kernel.org/pub/linux/kernel/v5.x/linux-5.4.7.tar.gz
+download dcd986e9e7a02500cf9c909030a4ca9e999adba2 \
+  https://kernel.org/pub/linux/kernel/v5.x/linux-5.4.8.tar.gz
 
 [ -z "$TARGET" ] && TARGET="${CROSS_BASE/-*/}"
 [ -z "$TARGET" ] && TARGET="$(uname -m)"

--- a/module/kernel
+++ b/module/kernel
@@ -1,7 +1,7 @@
 #!/bin/echo Use as an argument to mkroot.sh
 
-download 8685fffabe1ab8e6aaa2800dc0031d02273fa0a9 \
-  https://kernel.org/pub/linux/kernel/v5.x/linux-5.1.tar.gz
+download 90ce9015379f951b4da272f25302dfa0b0bc0123 \
+  https://kernel.org/pub/linux/kernel/v5.x/linux-5.4.7.tar.gz
 
 [ -z "$TARGET" ] && TARGET="${CROSS_BASE/-*/}"
 [ -z "$TARGET" ] && TARGET="$(uname -m)"

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ then
   if [ $(ls -1 output | wc -l) -eq 1 ]
   then
     ARCH=$(ls -1 output)
+    shift
   else
     ls output | grep -v '[.]failed' | xargs
     exit

--- a/run.sh
+++ b/run.sh
@@ -4,11 +4,16 @@
 
 if [ $# -lt 1 ]
 then
-  ls output | grep -v '[.]failed' | xargs
-  exit
+  if [ $(ls -1 output | wc -l) -eq 1 ]
+  then
+    ARCH=$(ls -1 output)
+  else
+    ls output | grep -v '[.]failed' | xargs
+    exit
+  fi
+else
+  ARCH="$1"
+  shift
 fi
-
-ARCH="$1"
-shift
 
 cd output/$ARCH && ./qemu-$ARCH.sh "$@"


### PR DESCRIPTION
"mkroot.sh" puts the build output in a "host" directory if
it doesn't get a CROSS_SHORT env.
So a simple "./mkroot.sh kernel" and "run.sh host" gives:
"./run.sh: line 14: ./qemu-host.sh: No such file or directory"