### PR TITLE
fix collecting initial -x arguments

### DIFF
--- a/mkroot.sh
+++ b/mkroot.sh
@@ -24,9 +24,9 @@ fi
 # Loop collecting initial -x arguments. (Simple, can't collate ala -nl .)
 while true
 do
-  [ "$1" == "-n" ] && N=1 && shift ||
-  [ "$1" == "-d" ] && D=1 && shift ||
-  [ "$1" == "-l" ] && WRAPDIR=wrap && shift || break
+  { [ "$1" == "-n" ] && N=1 && shift; } ||
+  { [ "$1" == "-d" ] && D=1 && shift; } ||
+  { [ "$1" == "-l" ] && WRAPDIR=wrap && shift; } || break
 done
 
 # Parse remaining args: assign NAME=VALUE to env vars, collect rest in $MODULES


### PR DESCRIPTION
* Grouped commands and conditionals to fix lasy evaluation when chained with && .

Example:
`true && true || echo yes && echo no`

see also:
https://www.gnu.org/software/bash/manual/html_node/Lists.html
https://www.gnu.org/software/bash/manual/html_node/Command-Grouping.html
https://unix.stackexchange.com/questions/548737/bash-chained-logical-operator-execution-order-lazy-evaluation